### PR TITLE
removed gpio.h reference. Doesn't compile otherwise

### DIFF
--- a/Firmware-IDF/lib/e-Paper-HAT-154/src/epdif.cpp
+++ b/Firmware-IDF/lib/e-Paper-HAT-154/src/epdif.cpp
@@ -27,7 +27,6 @@
 
 #include "epdif.h"
 #include "spibus.h"
-#include "gpio.h"
 #include <string.h>
 
 //Anonymous namespace


### PR DESCRIPTION
Will trying to compile the IDF- firmware, gpio.h was not found. I suppose this comes from the arduino version and is not needed in this case.